### PR TITLE
Fix price indexing

### DIFF
--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -28,16 +28,6 @@ class InventoryProductHelper extends ProductHelper
         //void
     }
 
-    protected function addMandatoryAttributes($products): void
-    {
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $products */
-        $products->addAttributeToSelect('special_price')
-            ->addAttributeToSelect('special_from_date')
-            ->addAttributeToSelect('special_to_date')
-            ->addAttributeToSelect('visibility')
-            ->addAttributeToSelect('status');
-    }
-
     public function productIsInStock($product, $storeId): bool
     {
         // Handled in ProductHelperPlugin


### PR DESCRIPTION
There is no reason to override the parent method for mandatory attributes. It prevent correct indexing of product prices, for exemple it prevents to index Excl Tax prices to be indexed.
