### PR TITLE
MAGE-1346 Update for 3.15.x (including stock quantity by warehouse) 

### DIFF
--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -25,6 +25,9 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryCatalog\Model\ResourceModel\AddStockDataToCollection;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Preference class to modify protected methods
+ */
 class InventoryProductHelper extends ProductHelper
 {
     public function __construct(
@@ -69,15 +72,6 @@ class InventoryProductHelper extends ProductHelper
         );
     }
 
-    protected function addInStock($defaultData, $customData, Product $product)
-    {
-        if (isset($defaultData['in_stock']) === false) {
-            $customData['in_stock'] = $this->productIsInStock($product, $product->getStoreId());
-        }
-
-        return $customData;
-    }
-
     /**
      * Explicitly apply stock filter from Magento_Inventory module
      */
@@ -92,11 +86,5 @@ class InventoryProductHelper extends ProductHelper
         } catch (LocalizedException $e) {
             $this->logger->error("Error applying MSI stock filter:" . $e->getMessage());
         }
-    }
-
-    public function productIsInStock($product, $storeId): bool
-    {
-        // Handled in ProductHelperPlugin
-        return true;
     }
 }

--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -28,16 +28,6 @@ class InventoryProductHelper extends ProductHelper
         //void
     }
 
-    protected function addMandatoryAttributes($products): void
-    {
-        /** @var \Magento\Catalog\Model\ResourceModel\Product\Collection $products */
-        $products->addAttributeToSelect('special_price')
-            ->addAttributeToSelect('special_from_date')
-            ->addAttributeToSelect('special_to_date')
-            ->addAttributeToSelect('visibility')
-            ->addAttributeToSelect('status');
-    }
-
     public function productIsInStock($product, $storeId): bool
     {
         // Handled in ProductHelperPlugin

--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -2,11 +2,73 @@
 
 namespace Algolia\AlgoliaSearchInventory\Helper;
 
+use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
+use Magento\Catalog\Api\Data\ProductInterfaceFactory;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Type;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\CatalogInventory\Helper\Stock;
+use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
+use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
+use Magento\Directory\Model\Currency as CurrencyHelper;
+use Magento\Eav\Model\Config;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventoryCatalog\Model\ResourceModel\AddStockDataToCollection;
+use Magento\Store\Model\StoreManagerInterface;
 
 class InventoryProductHelper extends ProductHelper
 {
+    public function __construct(
+        protected AddStockDataToCollection      $addStockDataToCollection,
+        protected StockHelper                   $localStockHelper,
+        Config                                  $eavConfig,
+        ConfigHelper                            $configHelper,
+        AlgoliaHelper                           $algoliaHelper,
+        DiagnosticsLogger                       $logger,
+        StoreManagerInterface                   $storeManager,
+        ManagerInterface                        $eventManager,
+        Visibility                              $visibility,
+        Stock                                   $deprecatedStockHelper,
+        CurrencyHelper                          $currencyManager,
+        Type                                    $productType,
+        CollectionFactory                       $productCollectionFactory,
+        GroupCollection                         $groupCollection,
+        GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
+        IndexNameFetcher                        $indexNameFetcher,
+        ReplicaManagerInterface                 $replicaManager,
+        ProductInterfaceFactory                 $productFactory,
+        ProductRecordBuilder                    $productRecordBuilder,
+    ) {
+        parent::__construct(
+            $eavConfig,
+            $configHelper,
+            $algoliaHelper,
+            $logger,
+            $storeManager,
+            $eventManager,
+            $visibility,
+            $deprecatedStockHelper,
+            $currencyManager,
+            $productType,
+            $productCollectionFactory,
+            $groupCollection,
+            $groupExcludedWebsiteRepository,
+            $indexNameFetcher,
+            $replicaManager,
+            $productFactory,
+            $productRecordBuilder
+        );
+    }
+
     protected function addInStock($defaultData, $customData, Product $product)
     {
         if (isset($defaultData['in_stock']) === false) {
@@ -17,15 +79,19 @@ class InventoryProductHelper extends ProductHelper
     }
 
     /**
-     * This method is overriden and left empty to remove the native stock filter behaviour
-     * (from CatalogInventory Helper)
-     *
-     * @param $products
-     * @param $storeId
+     * Explicitly apply stock filter from Magento_Inventory module
      */
     protected function addStockFilter($products, $storeId): void
     {
-        //void
+        try {
+            $this->addStockDataToCollection->execute(
+                $products,
+                !$this->configHelper->getShowOutOfStock($storeId),
+                $this->localStockHelper->getStockId($storeId)
+            );
+        } catch (LocalizedException $e) {
+            $this->logger->error("Error applying MSI stock filter:" . $e->getMessage());
+        }
     }
 
     public function productIsInStock($product, $storeId): bool

--- a/Helper/StockHelper.php
+++ b/Helper/StockHelper.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Algolia\AlgoliaSearchInventory\Helper;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
+use Magento\InventorySalesApi\Api\StockResolverInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class StockHelper
+{
+    public function __construct(
+        protected StoreManagerInterface $storeManager,
+        protected StockResolverInterface $stockResolver
+    ) { }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function getStockId(int $storeId): int
+    {
+        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
+        return (int) $this->stockResolver->execute(
+            SalesChannelInterface::TYPE_WEBSITE,
+            $this->storeManager->getWebsite($websiteId)->getCode()
+        )->getStockId();
+    }
+}

--- a/Plugin/Helper/ProductHelperPlugin.php
+++ b/Plugin/Helper/ProductHelperPlugin.php
@@ -8,6 +8,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\App\ResourceConnection;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
 
+/** @deprecated This plugin has been deprecated and should no longer be used.  */
 class ProductHelperPlugin
 {
     public function __construct(

--- a/Plugin/Helper/ProductHelperPlugin.php
+++ b/Plugin/Helper/ProductHelperPlugin.php
@@ -3,38 +3,18 @@
 namespace Algolia\AlgoliaSearchInventory\Plugin\Helper;
 
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
+use Algolia\AlgoliaSearchInventory\Helper\StockHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Framework\App\ResourceConnection;
 use Magento\InventoryIndexer\Model\StockIndexTableNameResolverInterface;
-use Magento\InventorySalesApi\Api\Data\SalesChannelInterface;
-use Magento\InventorySalesApi\Api\StockResolverInterface;
-use Magento\Store\Model\StoreManagerInterface;
 
 class ProductHelperPlugin
 {
-    /** @var StoreManagerInterface */
-    private $storeManager;
-
-    /** @var StockResolverInterface */
-    private $stockResolver;
-
-    /** @var StockIndexTableNameResolverInterface */
-    private $stockIndexTableNameResolver;
-
-    /** @var ResourceConnection */
-    private $resourceConnection;
-
     public function __construct(
-        StoreManagerInterface $storeManager,
-        StockResolverInterface $stockResolver,
-        StockIndexTableNameResolverInterface $stockIndexTableNameResolver,
-        ResourceConnection $resourceConnection
-    ) {
-        $this->storeManager = $storeManager;
-        $this->stockResolver = $stockResolver;
-        $this->stockIndexTableNameResolver = $stockIndexTableNameResolver;
-        $this->resourceConnection = $resourceConnection;
-    }
+        protected StockHelper $stockHelper,
+        protected StockIndexTableNameResolverInterface $stockIndexTableNameResolver,
+        protected ResourceConnection $resourceConnection
+    ) { }
 
     /**
      * @param ProductHelper $subject
@@ -72,26 +52,9 @@ class ProductHelperPlugin
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    private function getStockTableName($storeId)
+    protected function getStockTableName(int $storeId): string
     {
-        $tableName = $this->stockIndexTableNameResolver->execute($this->getStockId($storeId));
+        $tableName = $this->stockIndexTableNameResolver->execute($this->stockHelper->getStockId($storeId));
         return $this->resourceConnection->getTableName($tableName);
-    }
-
-    /**
-     * @param int $storeId
-     *
-     * @return int
-     *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    private function getStockId($storeId)
-    {
-        $websiteId = $this->storeManager->getStore($storeId)->getWebsiteId();
-        return (int)$this->stockResolver->execute(
-            SalesChannelInterface::TYPE_WEBSITE,
-            $this->storeManager->getWebsite($websiteId)->getCode()
-        )->getStockId();
     }
 }

--- a/Plugin/Service/Product/RecordBuilderPlugin.php
+++ b/Plugin/Service/Product/RecordBuilderPlugin.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Algolia\AlgoliaSearchInventory\Plugin\Service\Product;
+
+use Algolia\AlgoliaSearch\Service\Product\RecordBuilder;
+use Magento\Catalog\Model\Product;
+
+/**
+ * Plugin class to modify public methods
+ */
+class RecordBuilderPlugin
+{
+    public function afterProductIsInStock(
+        RecordBuilder $builder,
+        bool          $result,
+        Product       $product,
+        int           $storeId
+    ): bool
+    {
+        return $product->isSalable();
+    }
+
+    public function afterAddInStock(
+        RecordBuilder $builder,
+                      $result,
+                      $defaultData,
+                      $customData,
+        Product       $product
+    ): mixed
+    {
+        if (!isset($defaultData['in_stock'])) {
+            $result['in_stock'] = $builder->productIsInStock($product, $product->getStoreId());
+        }
+
+        return $result;
+    }
+}

--- a/Service/Product/InventoryProductRecordBuilder.php
+++ b/Service/Product/InventoryProductRecordBuilder.php
@@ -20,6 +20,9 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
+/**
+ * Preference class to modify protected methods
+ */
 class InventoryProductRecordBuilder extends RecordBuilder
 {
     const STOCK_QTY_ATTR = 'stock_qty';

--- a/Service/Product/InventoryProductRecordBuilder.php
+++ b/Service/Product/InventoryProductRecordBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Algolia\AlgoliaSearchInventory\Service\Product;
+
+use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
+use Algolia\AlgoliaSearch\Helper\ConfigHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
+use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
+use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
+use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\Product\RecordBuilder;
+use Algolia\AlgoliaSearchInventory\Helper\StockHelper;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\CatalogInventory\Api\StockRegistryInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventorySalesApi\Api\GetProductSalableQtyInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class InventoryProductRecordBuilder extends RecordBuilder
+{
+    const STOCK_QTY_ATTR = 'stock_qty';
+
+    public function __construct(
+        protected GetProductSalableQtyInterface $salableQty,
+        protected StockHelper                   $stockHelper,
+        ManagerInterface                        $eventManager,
+        DiagnosticsLogger                       $logger,
+        Visibility                              $visibility,
+        StoreManagerInterface                   $storeManager,
+        ConfigHelper                            $configHelper,
+        CategoryHelper                          $categoryHelper,
+        AlgoliaHelper                           $algoliaHelper,
+        ImageHelper                             $imageHelper,
+        StockRegistryInterface                  $stockRegistry,
+        PriceManager                            $priceManager
+    ){
+        parent::__construct(
+            $eventManager,
+            $logger,
+            $visibility,
+            $storeManager,
+            $configHelper,
+            $categoryHelper,
+            $algoliaHelper,
+            $imageHelper,
+            $stockRegistry,
+            $priceManager
+        );
+    }
+
+    /**
+     * Retrieve qty from MSI by stock ID
+     * @throws NoSuchEntityException
+     * @throws InputException
+     * @throws LocalizedException
+     */
+    protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product) {
+        if (!isset($defaultData[self::STOCK_QTY_ATTR])
+            && $this->isAttributeEnabled($additionalAttributes, self::STOCK_QTY_ATTR)) {
+            $customData[self::STOCK_QTY_ATTR] =
+                (int) $this->salableQty->execute(
+                    $product->getSku(),
+                    $this->stockHelper->getStockId($product->getStoreId())
+                );
+        }
+
+        return $customData;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Algolia Search Inventory module for Magento 2.3.x, 2.4.x and Algolia Search 3.* extension",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "require": {
     "magento/module-inventory-api": "1.*",
     "algolia/algoliasearch-magento-2": "^3.15.0"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "1.2.0",
   "require": {
     "magento/module-inventory-api": "1.*",
-    "algolia/algoliasearch-magento-2": "^3.15.0"
+    "algolia/algoliasearch-magento-2": "~3.15.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "1.1.0",
   "require": {
     "magento/module-inventory-api": "1.*",
-    "algolia/algoliasearch-magento-2": ">=1.12.0"  
+    "algolia/algoliasearch-magento-2": "^3.15.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,7 +22,6 @@
         />
     </type>
 
-    <preference for="Algolia\AlgoliaSearch\Service\Product\RecordBuilder" type="Algolia\AlgoliaSearchInventory\Service\Product\InventoryProductRecordBuilder" />
-
     <preference for="Algolia\AlgoliaSearch\Helper\Entity\ProductHelper" type="Algolia\AlgoliaSearchInventory\Helper\InventoryProductHelper" />
+    <preference for="Algolia\AlgoliaSearch\Service\Product\RecordBuilder" type="Algolia\AlgoliaSearchInventory\Service\Product\InventoryProductRecordBuilder" />
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -16,10 +16,9 @@
             sortOrder="9999"/>
     </type>
 
-    <type name="Algolia\AlgoliaSearch\Helper\Entity\ProductHelper">
-        <plugin name="algoliaInventoryIsInStockFilter"
-            type="Algolia\AlgoliaSearchInventory\Plugin\Helper\ProductHelperPlugin"
-        />
+    <type name="Algolia\AlgoliaSearch\Service\Product\RecordBuilder">
+        <plugin name="algoliaInventoryRecordBuilder"
+                type="Algolia\AlgoliaSearchInventory\Plugin\Service\Product\RecordBuilderPlugin"/>
     </type>
 
     <preference for="Algolia\AlgoliaSearch\Helper\Entity\ProductHelper" type="Algolia\AlgoliaSearchInventory\Helper\InventoryProductHelper" />

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -22,5 +22,7 @@
         />
     </type>
 
+    <preference for="Algolia\AlgoliaSearch\Service\Product\RecordBuilder" type="Algolia\AlgoliaSearchInventory\Service\Product\InventoryProductRecordBuilder" />
+
     <preference for="Algolia\AlgoliaSearch\Helper\Entity\ProductHelper" type="Algolia\AlgoliaSearchInventory\Helper\InventoryProductHelper" />
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.1.0">
+    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.2.0">
         <sequence>
             <module name="Magento_InventoryApi"/>
             <module name="Algolia_AlgoliaSearch"/>


### PR DESCRIPTION
**Summary**

This PR aims to correct a few observed issues with this extension while taking into account the very useful feedback of both @thomas-kl1 and @simonmaass. Thank you gents!

This is not the end game - just a stop gap before we improve support for MSI in the main extension. 

Goals:

- Allow independent iteration in the core module while addressing 3.15+ support
- Utilize proper API calls to `Magento_Inventory` for MSI
- Add stock quantity calculations based on `inventory_stock_x`
- Add support for new `RecordBuilderInterface` introduced in 3.15
- Remove confusing or outdated code 
- Minimize nested queries
- Maintain compatibility with existing module structure

**Result**

Example product "Joust" with separate inventory by website:
![image](https://github.com/user-attachments/assets/3cf38f56-17bb-49a3-999e-98605305b73e)
Test warehouse config ("Retail" vs "Wholesale")
![image](https://github.com/user-attachments/assets/66b85b12-c3ca-4ec3-957e-b8da0f5fe532)

Website 1 ("Retail")
![image](https://github.com/user-attachments/assets/8a5012f5-f18f-4ec7-9835-49d9709c5b8e)
![image](https://github.com/user-attachments/assets/378f01e2-24b8-44fe-a674-72becb2231b7)

Website 2 ("Wholesale")
![image](https://github.com/user-attachments/assets/434b3e11-f9cd-4e8b-9bfa-63217c680eb1)
![image](https://github.com/user-attachments/assets/05f94236-b26f-4d97-b780-9ea31ec78553)
