### PR TITLE
MAGE-1346 Update README and add clarity to compatiblity matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 Algolia Search Inventory for Magento 2.3.x and 2.4.x
 ==================
 
-![Latest version](https://img.shields.io/badge/latest-1.1.0-green)
+![Latest version](https://img.shields.io/badge/latest-1.2.0-green)
 
 This Algolia_AlgoliaSearchInventory is a community-developed module to provide compatibility between Magento (2.3.x, 2.4.x) Inventory feature and Algolia Search 1.12+ extension. Though Algolia is a contributor to this repository, there is no product roadmap for this module and it’s not aligned with the Algolia/Magento integration product releases.
 
 #### Compatibility
 
-| Extension Version | Algolia Search Magento2                                                          |
-|-------------------|----------------------------------------------------------------------------------|
-| v1.x              | [<=3.8.1](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.8.1) |
-| >= v1.0.3         | [3.9.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.9.0)   |
-| >= v1.0.5         | [3.10.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.10.3) |
-| >= v1.1.0         | [3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0) |
+| Algolia Search for Magento 2                                                                | Required Extension Version |
+|---------------------------------------------------------------------------------------------|----------------------------|
+| >=[3.8.1](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.8.1)            | 1.x                        |
+| >=[3.9.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.9.0), <3.10.3   | 1.0.3                      |
+| >=[3.10.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.10.3), <3.14.0 | ~1.0.5                     |
+| ~[3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0)           | ~1.1.0                     |
+| ~[3.15.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.15.0)           | ~1.2.0                     |
 
 
 


### PR DESCRIPTION
Updating README for v `1.2.0`.

- Reversed the columns: I feel it's a little more intuitive to list the main module version first, then the compatible extension. (i.e. what inventory module do I need for my version of the Algolia extension?)
- Added latest v 1.2.0
- Set boundaries for versions and applied [standard semantic formatting](https://jubianchi.github.io/semver-check/#/) 

