### PR TITLE
MAGE-1350 Update MSI module for v3.16

### DIFF
--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -9,6 +9,7 @@ use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
 use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
 use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\IndexSettingsHandler;
 use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
@@ -46,6 +47,7 @@ class InventoryProductHelper extends ProductHelper
         ProductInterfaceFactory            $productFactory,
         ProductRecordBuilder               $productRecordBuilder,
         FacetBuilder                       $facetBuilder,
+        IndexSettingsHandler               $indexSettingsHandler,
     ) {
         parent::__construct(
             $eavConfig,
@@ -63,7 +65,8 @@ class InventoryProductHelper extends ProductHelper
             $replicaManager,
             $productFactory,
             $productRecordBuilder,
-            $facetBuilder
+            $facetBuilder,
+            $indexSettingsHandler
         );
     }
 

--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -3,25 +3,22 @@
 namespace Algolia\AlgoliaSearchInventory\Helper;
 
 use Algolia\AlgoliaSearch\Api\Product\ReplicaManagerInterface;
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\ProductHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
 use Algolia\AlgoliaSearch\Service\IndexNameFetcher;
+use Algolia\AlgoliaSearch\Service\IndexOptionsBuilder;
+use Algolia\AlgoliaSearch\Service\Product\FacetBuilder;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder as ProductRecordBuilder;
 use Magento\Catalog\Api\Data\ProductInterfaceFactory;
-use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\Type;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\CatalogInventory\Helper\Stock;
-use Magento\Customer\Api\GroupExcludedWebsiteRepositoryInterface;
-use Magento\Customer\Model\ResourceModel\Group\Collection as GroupCollection;
-use Magento\Directory\Model\Currency as CurrencyHelper;
 use Magento\Eav\Model\Config;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\InventoryCatalog\Model\ResourceModel\AddStockDataToCollection;
 use Magento\Store\Model\StoreManagerInterface;
 
@@ -31,44 +28,42 @@ use Magento\Store\Model\StoreManagerInterface;
 class InventoryProductHelper extends ProductHelper
 {
     public function __construct(
-        protected AddStockDataToCollection      $addStockDataToCollection,
-        protected StockHelper                   $localStockHelper,
-        Config                                  $eavConfig,
-        ConfigHelper                            $configHelper,
-        AlgoliaHelper                           $algoliaHelper,
-        DiagnosticsLogger                       $logger,
-        StoreManagerInterface                   $storeManager,
-        ManagerInterface                        $eventManager,
-        Visibility                              $visibility,
-        Stock                                   $deprecatedStockHelper,
-        CurrencyHelper                          $currencyManager,
-        Type                                    $productType,
-        CollectionFactory                       $productCollectionFactory,
-        GroupCollection                         $groupCollection,
-        GroupExcludedWebsiteRepositoryInterface $groupExcludedWebsiteRepository,
-        IndexNameFetcher                        $indexNameFetcher,
-        ReplicaManagerInterface                 $replicaManager,
-        ProductInterfaceFactory                 $productFactory,
-        ProductRecordBuilder                    $productRecordBuilder,
+        protected AddStockDataToCollection $addStockDataToCollection,
+        protected StockHelper              $localStockHelper,
+        Config                             $eavConfig,
+        ConfigHelper                       $configHelper,
+        AlgoliaConnector                   $algoliaConnector,
+        IndexOptionsBuilder                $indexOptionsBuilder,
+        DiagnosticsLogger                  $logger,
+        StoreManagerInterface              $storeManager,
+        ManagerInterface                   $eventManager,
+        Visibility                         $visibility,
+        Stock                              $deprecatedStockHelper,
+        Type                               $productType,
+        CollectionFactory                  $productCollectionFactory,
+        IndexNameFetcher                   $indexNameFetcher,
+        ReplicaManagerInterface            $replicaManager,
+        ProductInterfaceFactory            $productFactory,
+        ProductRecordBuilder               $productRecordBuilder,
+        FacetBuilder                       $facetBuilder,
     ) {
         parent::__construct(
             $eavConfig,
             $configHelper,
-            $algoliaHelper,
+            $algoliaConnector,
+            $indexOptionsBuilder,
             $logger,
             $storeManager,
             $eventManager,
             $visibility,
             $deprecatedStockHelper,
-            $currencyManager,
             $productType,
             $productCollectionFactory,
-            $groupCollection,
-            $groupExcludedWebsiteRepository,
             $indexNameFetcher,
             $replicaManager,
             $productFactory,
-            $productRecordBuilder
+            $productRecordBuilder,
+            $facetBuilder
         );
     }
 

--- a/Plugin/Service/Product/RecordBuilderPlugin.php
+++ b/Plugin/Service/Product/RecordBuilderPlugin.php
@@ -4,6 +4,7 @@ namespace Algolia\AlgoliaSearchInventory\Plugin\Service\Product;
 
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder;
 use Magento\Catalog\Model\Product;
+use Algolia\AlgoliaSearchInventory\Service\Product\InventoryProductRecordBuilder;
 
 /**
  * Plugin class to modify public methods
@@ -28,8 +29,8 @@ class RecordBuilderPlugin
         Product       $product
     ): mixed
     {
-        if (!isset($defaultData['in_stock'])) {
-            $result['in_stock'] = $builder->productIsInStock($product, $product->getStoreId());
+        if (!isset($defaultData[InventoryProductRecordBuilder::ATTR_IN_STOCK])) {
+            $result[InventoryProductRecordBuilder::ATTR_IN_STOCK] = $builder->productIsInStock($product, $product->getStoreId());
         }
 
         return $result;

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search Inventory for Magento 2.3.x and 2.4.x
 ==================
 
-![Latest version](https://img.shields.io/badge/latest-1.2.0-green)
+![Latest version](https://img.shields.io/badge/latest-1.3.0-green)
 
 This Algolia_AlgoliaSearchInventory is a community-developed module to provide compatibility between Magento (2.3.x, 2.4.x) Inventory feature and Algolia Search 1.12+ extension. Though Algolia is a contributor to this repository, there is no product roadmap for this module and it’s not aligned with the Algolia/Magento integration product releases.
 
@@ -14,6 +14,7 @@ This Algolia_AlgoliaSearchInventory is a community-developed module to provide c
 | >=[3.10.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.10.3), <3.14.0 | ~1.0.5                     |
 | ~[3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0)           | ~1.1.0                     |
 | ~[3.15.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.15.0)           | ~1.2.0                     |
+| ~[3.16.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.0)           | ~1.3.0                     |
 
 
 

--- a/Service/Product/InventoryProductRecordBuilder.php
+++ b/Service/Product/InventoryProductRecordBuilder.php
@@ -26,7 +26,8 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class InventoryProductRecordBuilder extends RecordBuilder
 {
-    const STOCK_QTY_ATTR = 'stock_qty';
+    const ATTR_STOCK_QTY = 'stock_qty';
+    const ATTR_IN_STOCK = 'in_stock';
 
     public function __construct(
         protected GetProductSalableQtyInterface $salableQty,
@@ -65,13 +66,15 @@ class InventoryProductRecordBuilder extends RecordBuilder
      * @throws LocalizedException
      */
     protected function addStockQty($defaultData, $customData, $additionalAttributes, Product $product) {
-        if (!isset($defaultData[self::STOCK_QTY_ATTR])
-            && $this->isAttributeEnabled($additionalAttributes, self::STOCK_QTY_ATTR)) {
-            $customData[self::STOCK_QTY_ATTR] =
-                (int) $this->salableQty->execute(
-                    $product->getSku(),
-                    $this->stockHelper->getStockId($product->getStoreId())
-                );
+        if (!isset($defaultData[self::ATTR_STOCK_QTY])
+            && $this->isAttributeEnabled($additionalAttributes, self::ATTR_STOCK_QTY)) {
+            $customData[self::ATTR_STOCK_QTY] = !!$customData[self::ATTR_IN_STOCK]
+                 ? (int) $this->salableQty->execute(
+                        $product->getSku(),
+                        $this->stockHelper->getStockId($product->getStoreId())
+                    )
+                : 0 // Avoids error: Can't check requested quantity for products without Source Items support.
+            ;
         }
 
         return $customData;

--- a/Service/Product/InventoryProductRecordBuilder.php
+++ b/Service/Product/InventoryProductRecordBuilder.php
@@ -2,12 +2,13 @@
 
 namespace Algolia\AlgoliaSearchInventory\Service\Product;
 
-use Algolia\AlgoliaSearch\Helper\AlgoliaHelper;
 use Algolia\AlgoliaSearch\Helper\ConfigHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\CategoryHelper;
 use Algolia\AlgoliaSearch\Helper\Entity\Product\PriceManager;
 use Algolia\AlgoliaSearch\Helper\Image as ImageHelper;
 use Algolia\AlgoliaSearch\Logger\DiagnosticsLogger;
+use Algolia\AlgoliaSearch\Service\AlgoliaConnector;
+use Algolia\AlgoliaSearch\Service\Category\RecordBuilder as CategoryRecordBuilder;
 use Algolia\AlgoliaSearch\Service\Product\RecordBuilder;
 use Algolia\AlgoliaSearchInventory\Helper\StockHelper;
 use Magento\Catalog\Model\Product;
@@ -36,7 +37,8 @@ class InventoryProductRecordBuilder extends RecordBuilder
         StoreManagerInterface                   $storeManager,
         ConfigHelper                            $configHelper,
         CategoryHelper                          $categoryHelper,
-        AlgoliaHelper                           $algoliaHelper,
+        CategoryRecordBuilder                   $categoryRecordBuilder,
+        AlgoliaConnector                        $algoliaConnector,
         ImageHelper                             $imageHelper,
         StockRegistryInterface                  $stockRegistry,
         PriceManager                            $priceManager
@@ -48,7 +50,8 @@ class InventoryProductRecordBuilder extends RecordBuilder
             $storeManager,
             $configHelper,
             $categoryHelper,
-            $algoliaHelper,
+            $categoryRecordBuilder,
+            $algoliaConnector,
             $imageHelper,
             $stockRegistry,
             $priceManager

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
   "description": "Algolia Search Inventory module for Magento 2.3.x, 2.4.x and Algolia Search 3.* extension",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "1.2.0",
+  "version": "1.3.0",
   "require": {
     "magento/module-inventory-api": "1.*",
-    "algolia/algoliasearch-magento-2": "~3.15.0"
+    "algolia/algoliasearch-magento-2": "~3.16.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.2.0">
+    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.3.0">
         <sequence>
             <module name="Magento_InventoryApi"/>
             <module name="Algolia_AlgoliaSearch"/>


### PR DESCRIPTION
This PR aligns the MSI module with the latest 3.16 release and also provides a fix for an issue with products missing sources when "Display Out of Stock Products" is set to "Yes" and MSI is enabled. 

If a source is not defined for a SKU when using MSI the inventory will show as out of stock with 0 on hand. 

For example Joust is assigned sources:
<img width="1389" height="498" alt="2025-08-08_17-24-29" src="https://github.com/user-attachments/assets/b4826e00-f688-4bcc-8a42-eba44fa54b02" />
But Crown Summit is still set to default.

Resulting Algolia records:
<img width="1037" height="1508" alt="2025-08-08_17-22-51" src="https://github.com/user-attachments/assets/a9ecfd47-0c73-4b67-bf66-7879e2e83dba" />
