### PR TITLE
MAGE-1410 Update MSI extension for 3.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,16 @@ This Algolia_AlgoliaSearchInventory is a community-developed module to provide c
 
 #### Compatibility
 
-| Algolia Search for Magento 2                                                                | Required Extension Version |
-|---------------------------------------------------------------------------------------------|----------------------------|
-| >=[3.8.1](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.8.1)            | 1.x                        |
-| >=[3.9.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.9.0), <3.10.3   | 1.0.3                      |
-| >=[3.10.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.10.3), <3.14.0 | ~1.0.5                     |
-| ~[3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0)           | ~1.1.0                     |
-| ~[3.15.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.15.0)           | ~1.2.0                     |
-| ~[3.16.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.0)           | ~1.3.0                     |
+| Algolia Search for Magento 2                                                                                                                                         | Required Extension Version |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| \>=[3.8.1](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.8.1)                                                                                    | 1.x                        |
+| \>=[3.9.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.9.0), <3.10.3                                                                           | 1.0.3                      |
+| \>=[3.10.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.10.3), <3.14.0                                                                         | ~1.0.5                     |
+| ~[3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0)                                                                                    | ~1.1.0                     |
+| ~[3.15.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.15.0)                                                                                    | ~1.2.0                     |
+| ~[3.16.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.0), ~[3.17.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.17.0) | ~1.3.1                     |
 
-
-
-Installation
-------------
-
+## Installation
 The easiest way to install the extension is to use [Composer](https://getcomposer.org/)
 
 Run the following commands:
@@ -28,3 +24,17 @@ Run the following commands:
 - ```$ composer require algolia/algoliasearch-inventory-magento-2```
 - ```$ bin/magento module:enable Algolia_AlgoliaSearchInventory```
 - ```$ bin/magento setup:upgrade && bin/magento setup:static-content:deploy```
+
+## Upgrades
+
+When upgrading the [base Algolia extension](https://github.com/algolia/algoliasearch-magento-2) it is best to upgrade
+ this inventory extension at the same time, e.g.
+
+```
+composer require \
+    algolia/algoliasearch-magento-2:~3.17.0 \
+    algolia/algoliasearch-inventory-magento-2 \
+    --update-with-dependencies
+```
+
+This will ensure that the compatible version of the inventory extension is installed. 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
   "description": "Algolia Search Inventory module for Magento 2.3.x, 2.4.x and Algolia Search 3.* extension",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "1.3.0",
+  "version": "1.3.1",
   "require": {
     "magento/module-inventory-api": "1.*",
-    "algolia/algoliasearch-magento-2": "~3.16.0"
+    "algolia/algoliasearch-magento-2": "~3.16.0 || ~3.17.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.3.0">
+    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.3.1">
         <sequence>
             <module name="Magento_InventoryApi"/>
             <module name="Algolia_AlgoliaSearch"/>


### PR DESCRIPTION
This PR updates composer dependencies after verifying compatibility with [`3.17.0-beta.1`](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.17.0-beta.1).

It also provides an updated `README.md` to provide guidance on keeping this extension in sync with the primary Algolia extension. 