### PR TITLE
MAGE-1667 Backport stock_status_index double-join fix to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGE LOG
 
+## 1.4.1
+- Fixed `Zend_Db_Select_Exception` ("correlation name 'stock_status_index' defined more than once")
+  when a Recommend widget renders on the storefront cart page. The MSI stock filter now sets the
+  `has_stock_status_filter` collection flag so Magento's frontend `add_stock_information` plugin
+  does not add a second join for the same alias.
+- Constrained the Algolia_AlgoliaSearch dependency to `>=3.16.3 <3.17.0 || >=3.17.3 <3.19.0`, 
+  preserving the existing 3.16.3/3.17.3 minimums and adding an upper bound. Version 3.19.0 changed
+  `Service\Product\RecordBuilder::__construct()` to require two additional arguments, which this
+  module's `InventoryProductRecordBuilder` does not forward. Use 1.5.0 or later with 3.19.0+.
+
 ## 1.4.0
 - Fix compatibility with versions 3.16.3 and 3.17.3 of the Algolia_AlgoliaSearch module 
 

--- a/Helper/InventoryProductHelper.php
+++ b/Helper/InventoryProductHelper.php
@@ -28,6 +28,15 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class InventoryProductHelper extends ProductHelper
 {
+    /**
+     * Magento core's idempotency latch for the `stock_status_index` correlation name.
+     * This is not a semantic stock marker: `CatalogInventory\Helper\Stock::addIsInStockFilterToCollection()`
+     * guards on `hasFlag()`, so setting it only tells core's frontend `add_stock_information`
+     * plugin that the alias is already taken. Algolia keeps full control of which products
+     * are filtered. Core exposes no public constant for this key.
+     */
+    protected const HAS_STOCK_STATUS_FILTER = 'has_stock_status_filter';
+
     public function __construct(
         protected AddStockDataToCollection $addStockDataToCollection,
         protected StockHelper              $localStockHelper,
@@ -81,6 +90,7 @@ class InventoryProductHelper extends ProductHelper
                 !$this->configHelper->getShowOutOfStock($storeId),
                 $this->localStockHelper->getStockId($storeId)
             );
+            $products->setFlag(self::HAS_STOCK_STATUS_FILTER, true);
         } catch (LocalizedException $e) {
             $this->logger->error("Error applying MSI stock filter:" . $e->getMessage());
         }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Algolia Search Inventory for Magento 2.3.x and 2.4.x
 ==================
 
-![Latest version](https://img.shields.io/badge/latest-1.4.0-green)
+![Latest version](https://img.shields.io/badge/latest-1.4.1-green)
 
 This Algolia_AlgoliaSearchInventory is a community-developed module to provide compatibility between Magento (2.3.x, 2.4.x) Inventory feature and Algolia Search 1.12+ extension. Though Algolia is a contributor to this repository, there is no product roadmap for this module and it’s not aligned with the Algolia/Magento integration product releases.
 
@@ -15,7 +15,7 @@ This Algolia_AlgoliaSearchInventory is a community-developed module to provide c
 | ~[3.14.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.14.0)                                                                                                    | ~1.1.0                     |
 | ~[3.15.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.15.0)                                                                                                    | ~1.2.0                     |
 | \>=[3.16.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.0) <3.16.3, \>=[3.17.0](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.17.0) <3.17.3 | ~1.3.1                     |
-| \>=[3.16.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.3), \>=[3.17.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.17.3)               | ~1.4.0                     |
+| \>=[3.16.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.16.3) <3.17.0, \>=[3.17.3](https://github.com/algolia/algoliasearch-magento-2/releases/tag/3.17.3) <3.19.0 | ~1.4.1                     |
 
 ## Installation
 The easiest way to install the extension is to use [Composer](https://getcomposer.org/)

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
   "description": "Algolia Search Inventory module for Magento 2.3.x, 2.4.x and Algolia Search 3.* extension",
   "type": "magento2-module",
   "license": ["MIT"],
-  "version": "1.4.0",
+  "version": "1.4.1",
   "require": {
     "magento/module-inventory-api": "1.*",
-    "algolia/algoliasearch-magento-2": ">=3.16.3 || >=3.17.3"
+    "algolia/algoliasearch-magento-2": ">=3.16.3 <3.17.0 || >=3.17.3 <3.19.0"
   },
   "autoload": {
     "files": [ "registration.php" ],

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.4.0">
+    <module name="Algolia_AlgoliaSearchInventory" setup_version="1.4.1">
         <sequence>
             <module name="Magento_InventoryApi"/>
             <module name="Algolia_AlgoliaSearch"/>


### PR DESCRIPTION
## Summary

This is a fix for the following bug:

Recommend widgets throw `Zend_Db_Select_Exception: You cannot define a correlation name 'stock_status_index' more than once` on the storefront cart page when `Algolia_AlgoliaSearchInventory` is enabled. 

Root cause: 

`InventoryProductHelper::addStockFilter()` joins `stock_status_index` via MSI's `AddStockDataToCollection` without setting the `has_stock_status_filter` collection flag, so Magento's frontend-only `add_stock_information` plugin joins the same alias a second time when the collection loads during a cart render.

## What's changed
- Sets `has_stock_status_filter` on successful stock join (mirrors what core itself does in `Quote\Item\Collection`, `Reorder`, `ConfigurableProduct\Type\Configurable`,  `AdvancedCheckout\Helper\Data`).
- Constrains the `algolia/algoliasearch-magento-2` requirement to  `>=3.16.3 <3.17.0 || >=3.17.3 <3.19.0`, in anticipation of the 3.19.0 release which expands the constructor `Service\Product\RecordBuilder::__construct()` to 14 arguments
- Bumps `composer.json` version and `etc/module.xml` setup_version to 1.4.1.
- Updates the README compatibility matrix and latest-version badge.
